### PR TITLE
Update player_row.lua

### DIFF
--- a/lua/sui_scoreboard/client/player_row.lua
+++ b/lua/sui_scoreboard/client/player_row.lua
@@ -133,9 +133,9 @@ function PANEL:UpdatePlayerData()
 	
 	-- Show the super awesome port of the vanilla gmod volume slider when right click
 	self.lblMute.DoRightClick = function()
-		if IsValid(ply) and ply ~= LocalPlayer() then
+		--if IsValid(ply) and ply ~= LocalPlayer() then --player is always valid
 			self:ShowMicVolumeSlider()
-		end
+		--end
 
 	end
 


### PR DESCRIPTION
Testing ply IsValid and not-LocalPlayer in DoRightClick was always returning false, preventing slider from opening. Check is not required.